### PR TITLE
added filepicker to load rust engine.

### DIFF
--- a/XiEditor/MainWindow.xaml.cs
+++ b/XiEditor/MainWindow.xaml.cs
@@ -40,7 +40,29 @@ namespace XiEditor
 		{
 			InitializeComponent();
 
-			var filename = @"C:\Users\Clayton\Source\xi-editor\rust\target\debug\xicore.exe";
+
+            string filename = (string)Registry.GetValue(@"HKEY_LOCAL_MACHINE\SOFTWARE\xieditor\", "path", null);
+            if (String.IsNullOrWhiteSpace(filename) )
+            {
+
+                OpenFileDialog xiEnginePicker = new OpenFileDialog();
+
+                xiEnginePicker.InitialDirectory = "c:\\";
+                xiEnginePicker.Filter = "xi-editor core (*.exe)|*.exe|All files (*.*)|*.*";
+                xiEnginePicker.Title = "Please select the xi-editor.exe in your rust > target directory.";
+
+                if (xiEnginePicker.ShowDialog() == true )
+                {
+                    filename = xiEnginePicker.FileName;
+                    Registry.SetValue(@"HKEY_LOCAL_MACHINE\SOFTWARE\xieditor\", "path", filename );
+                } else
+                {
+                    System.Windows.MessageBox.Show("You must select a xi-editor core engine.");
+                    Environment.Exit(1);
+                }
+           }
+
+            // filename = @"C:\Users\Clayton\Source\xi-editor\rust\target\debug\xicore.exe";
 			coreConnection = new CoreConnection(filename, delegate (object data) {
 				handleCoreCmd(data);
 			});

--- a/XiEditor/XiEditor.csproj
+++ b/XiEditor/XiEditor.csproj
@@ -104,6 +104,9 @@
   <ItemGroup>
     <None Include="App.config" />
   </ItemGroup>
+  <ItemGroup>
+    <WCFMetadata Include="Service References\" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
Hi Sineaggi,

I'd like to contribute to this project. To make things easier in the future I just added a quick and simple file picker to select the xi-editor core, it stores this in the registry.

In the future the xi-editor would of course be bundled with the application in install and the registry key won't be necessary, however for now it's a good solution to allow multiple people to work on the codebase.

I hope that's okay.
